### PR TITLE
Change "bucket" algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ end
 
 For more information about the format of Noid patterns, see pages 8-10 of the [Noid documentation](https://wiki.ucop.edu/download/attachments/16744482/noid.pdf).
 
+### Treeifier
+
+To override the default "treeifier", simply pass in a callable object (responds to `call` and takes a string) via something like this in e.g. `config/initializers/active_fedora-noid.rb`:
+
+```ruby
+require 'active_fedora/noid'
+
+ActiveFedora::Noid.configure do |config|
+  config.treeifier = ->(id) { id.reverse }
+end
+```
+
+In this way, you can customize how assets will be put into buckets.  Keeping the previous behavior is as easy as passing in a lambda that just returns the id as-is.
+
+**NOTE**: You must NOT change the treeifier after using it to store assets in production!  Doing so will cause your system to be unable to find existing assets!
+
 ### Custom minters
 
 If you don't want your minter's state to be persisted, you may also pass in your own minter.  First write up a minter class that looks like the following:

--- a/lib/active_fedora/noid.rb
+++ b/lib/active_fedora/noid.rb
@@ -15,7 +15,7 @@ module ActiveFedora
       end
 
       def treeify(identifier)
-        (identifier.scan(/..?/).first(4) + [identifier]).join('/')
+        (config.treeifier.call(identifier).scan(/..?/).first(4) + [identifier]).join('/')
       end
     end
   end

--- a/lib/active_fedora/noid/config.rb
+++ b/lib/active_fedora/noid/config.rb
@@ -14,9 +14,10 @@ module ActiveFedora
       end
 
       # Default behavior turns an identifier into a completely unpredictable
-      # base-36 value for well-distributed "buckets"
+      # base-16 value for well-distributed "buckets", none of which can have
+      # more than 256 items (at least until asset count is in the billions)
       def treeifier
-        @treeifier ||= ->(id) { Digest::MD5.hexdigest(id).to_i(16).to_s(36) }
+        @treeifier ||= ->(id) { Digest::MD5.hexdigest(id) }
       end
 
       def translate_uri_to_id

--- a/lib/active_fedora/noid/config.rb
+++ b/lib/active_fedora/noid/config.rb
@@ -1,7 +1,9 @@
+require 'digest/md5'
+
 module ActiveFedora
   module Noid
     class Config
-      attr_writer :template, :translate_uri_to_id, :translate_id_to_uri, :statefile
+      attr_writer :template, :translate_uri_to_id, :translate_id_to_uri, :statefile, :treeifier
 
       def template
         @template ||= '.reeddeeddk'
@@ -9,6 +11,12 @@ module ActiveFedora
 
       def statefile
         @statefile ||= '/tmp/minter-state'
+      end
+
+      # Default behavior turns an identifier into a completely unpredictable
+      # base-36 value for well-distributed "buckets"
+      def treeifier
+        @treeifier ||= ->(id) { Digest::MD5.hexdigest(id).to_i(16).to_s(36) }
       end
 
       def translate_uri_to_id

--- a/spec/unit/noid_spec.rb
+++ b/spec/unit/noid_spec.rb
@@ -15,7 +15,7 @@ describe ActiveFedora::Noid do
     context "with the default treeifier" do
       subject { ActiveFedora::Noid.treeify(id) }
       let(:id) { 'abc123def45' }
-      it { is_expected.to eq '2k/a5/k2/wg/abc123def45' }
+      it { is_expected.to eq '2b/4c/7a/ce/abc123def45' }
     end
 
     context "with overridden treeifier" do

--- a/spec/unit/noid_spec.rb
+++ b/spec/unit/noid_spec.rb
@@ -12,8 +12,19 @@ describe ActiveFedora::Noid do
   end
 
   describe '#treeify' do
-    subject { ActiveFedora::Noid.treeify(id) }
-    let(:id) { 'abc123def45' }
-    it { is_expected.to eq 'ab/c1/23/de/abc123def45' }
+    context "with the default treeifier" do
+      subject { ActiveFedora::Noid.treeify(id) }
+      let(:id) { 'abc123def45' }
+      it { is_expected.to eq '2k/a5/k2/wg/abc123def45' }
+    end
+
+    context "with overridden treeifier" do
+      subject { ActiveFedora::Noid.treeify(id) }
+      let(:id) { 'abc123def45' }
+      before do
+        allow(ActiveFedora::Noid.config).to receive(:treeifier).and_return(->(id) { id })
+      end
+      it { is_expected.to eq 'ab/c1/23/de/abc123def45' }
+    end
   end
 end


### PR DESCRIPTION
Changes the system to use MD5 to produce base-16 values, instead of relying on IDs directly.  Using MD5 ensures very random-like buckets for better distribution of files across buckets, and in a perfect world, you won't see very many directories/files in any given "bucket" until you have a lot of files.

The existing system, since it uses just the id as-is, had a few concerns for us:

* It'll put most assets into the same few directories, especially with alphanumeric noids.  Testing 1000 assets, we ended up with all of them showing up in 25/14/nX, where "X" is one of about ten letters.  Further testing suggests it would take a long time before a new bucket at levels one or two would be created (the "25" or "14" in /25/14/nX).
* If the id is 8 digits or fewer, every asset will live in its own directory - probably not a real problem, but it seems like a high directory-to-file ratio
* If the id is extremely long (as an example, 14 digits), way too many assets will live in the same directory: 12345678901234 turns into /12/34/56/78 - and that directory will hold 12345678000000 through 12345678999999, or nearly a million assets.

I'm sure this approach is not the best way to do it, but at the least, a configurable "treeifier" seems like something worthwhile.