### PR TITLE
Revert treeifier functionality. Fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Override your ActiveFedora-based applications with opaque [Noid](https://wiki.uc
     * [Overriding default behavior](#overriding-default-behavior)
       * [Minter state (for replayability)](#minter-state-for-replayability)
       * [Identifier template](#identifier-template)
-      * [Treeifier](#treeifier)
       * [Custom minters](#custom-minters)
   * [Help](#help)
   * [Acknowledgments](#acknowledgments)
@@ -122,22 +121,6 @@ end
 ```
 
 For more information about the format of Noid patterns, see pages 8-10 of the [Noid documentation](https://wiki.ucop.edu/download/attachments/16744482/noid.pdf).
-
-### Treeifier
-
-To override the default "treeifier" -- an MD5 checksum, the rationale for which is described in [#3](https://github.com/projecthydra-labs/active_fedora-noid/pull/3) -- simply pass in a callable object (responds to `call` and takes a string) via code like this in e.g. `config/initializers/active_fedora-noid.rb`:
-
-```ruby
-require 'active_fedora/noid'
-
-ActiveFedora::Noid.configure do |config|
-  config.treeifier = ->(id) { id.reverse }
-end
-```
-
-In this way, you can customize how assets will be put into Fedora containers.
-
-**NOTE**: You should NOT change the treeifier after using it to store assets in production!  Doing so will cause your system to be unable to find existing assets.
 
 ### Custom minters
 

--- a/lib/active_fedora/noid.rb
+++ b/lib/active_fedora/noid.rb
@@ -15,7 +15,7 @@ module ActiveFedora
       end
 
       def treeify(identifier)
-        (config.treeifier.call(identifier).scan(/..?/).first(4) + [identifier]).join('/')
+        (identifier.scan(/..?/).first(4) + [identifier]).join('/')
       end
     end
   end

--- a/lib/active_fedora/noid/config.rb
+++ b/lib/active_fedora/noid/config.rb
@@ -1,9 +1,7 @@
-require 'digest/md5'
-
 module ActiveFedora
   module Noid
     class Config
-      attr_writer :template, :translate_uri_to_id, :translate_id_to_uri, :statefile, :treeifier
+      attr_writer :template, :translate_uri_to_id, :translate_id_to_uri, :statefile
 
       def template
         @template ||= '.reeddeeddk'
@@ -11,13 +9,6 @@ module ActiveFedora
 
       def statefile
         @statefile ||= '/tmp/minter-state'
-      end
-
-      # Default behavior turns an identifier into a completely unpredictable
-      # base-16 value for well-distributed "buckets", none of which can have
-      # more than 256 items (at least until asset count is in the billions)
-      def treeifier
-        @treeifier ||= ->(id) { Digest::MD5.hexdigest(id) }
       end
 
       def translate_uri_to_id

--- a/spec/unit/noid_spec.rb
+++ b/spec/unit/noid_spec.rb
@@ -12,19 +12,8 @@ describe ActiveFedora::Noid do
   end
 
   describe '#treeify' do
-    context "with the default treeifier" do
-      subject { ActiveFedora::Noid.treeify(id) }
-      let(:id) { 'abc123def45' }
-      it { is_expected.to eq '2b/4c/7a/ce/abc123def45' }
-    end
-
-    context "with overridden treeifier" do
-      subject { ActiveFedora::Noid.treeify(id) }
-      let(:id) { 'abc123def45' }
-      before do
-        allow(ActiveFedora::Noid.config).to receive(:treeifier).and_return(->(id) { id })
-      end
-      it { is_expected.to eq 'ab/c1/23/de/abc123def45' }
-    end
+    subject { ActiveFedora::Noid.treeify(id) }
+    let(:id) { 'abc123def45' }
+    it { is_expected.to eq 'ab/c1/23/de/abc123def45' }
   end
 end


### PR DESCRIPTION
The treeifier was added in #3 as a workaround to a bug in the underlying 'noid' gem. The workaround spawned a discussion of how best to bucket assets that generated a number of possible solutions, none of which seemed satisfactory. The underlying noid bug is now resolved, and the treeifier functionality was released temporarily in AF::Noid 1.0.0 which was yanked, so no one's using the functionality. Therefore, be it resolved that the treeifier is now put to rest, may it rest in peace. (Thanks, @jechols, @hackmastera, and others for helping me through this.)