### PR TITLE
Use Marshal to serialize minter state rather than YAML

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,5 @@ require 'rspec/core/rake_task'
 
 task default: :spec
 RSpec::Core::RakeTask.new
+
+import './lib/tasks/noid_tasks.rake'

--- a/active_fedora-noid.gemspec
+++ b/active_fedora-noid.gemspec
@@ -23,4 +23,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rspec', '~> 3.2'
+
+  spec.post_install_message = <<-END
+NOTE: ActiveFedora::Noid 1.0.0 included a change that breaks existing minter
+statefiles. Run the `active_fedora:noid:migrate_statefile` rake task to migrate
+your statefile. (If you're using a custom statefile, not /tmp/minter-state,, set
+an environment variable called AFNOID_STATEFILE with its path.)
+END
+
 end

--- a/lib/tasks/noid_tasks.rake
+++ b/lib/tasks/noid_tasks.rake
@@ -1,0 +1,29 @@
+require 'active_fedora/noid'
+require 'noid'
+require 'yaml'
+
+namespace :active_fedora do
+  namespace :noid do
+    desc 'Migrate minter state file from YAML to Marshal'
+    task :migrate_statefile do
+      statefile = ENV.fetch('AFNOID_STATEFILE', ActiveFedora::Noid.config.statefile)
+      raise "File not found: #{statefile}\nAborting" unless File.exist?(statefile)
+      puts "Migrating #{statefile} from YAML to Marshal serialization..."
+      File.open(statefile, File::RDWR | File::CREAT, 0644) do |f|
+        f.flock(File::LOCK_EX)
+        begin
+          yaml_state = YAML.load(f)
+        rescue Psych::SyntaxError
+          raise "File not valid YAML: #{statefile}\nAborting."
+        end
+        minter = Noid::Minter.new(yaml_state)
+        f.rewind
+        new_state = Marshal.dump(minter.dump)
+        f.write(new_state)
+        f.flush
+        f.truncate(f.pos)
+      end
+      puts "Done!"
+    end
+  end
+end


### PR DESCRIPTION
Because performance, especially for stateful minters with millions or billions of identifiers. See https://gist.github.com/mjgiarlo/1b09f710a625ffb92a8f#file-benchmark-results-with-marshal-serialization. Also provide a rake task for one-time migration of an existing minter state file from YAML to Marshal format.