### PR TITLE
Force UTF-8 encoding of minter state files

### DIFF
--- a/lib/active_fedora/noid/synchronized_minter.rb
+++ b/lib/active_fedora/noid/synchronized_minter.rb
@@ -38,16 +38,20 @@ module ActiveFedora
         { template: template }
       end
 
+      def file_opts
+        { encoding: Encoding::ASCII_8BIT }
+      end
+
       def next_id
         id = ''
-        ::File.open(statefile, ::File::RDWR|::File::CREAT, 0644) do |f|
+        ::File.open(statefile, ::File::RDWR|::File::CREAT, 0644, file_opts) do |f|
           f.flock(::File::LOCK_EX)
           state = state_for(f)
           minter = ::Noid::Minter.new(state)
           id = minter.mint
           f.rewind
           new_state = Marshal.dump(minter.dump)
-          f.write(new_state)
+          f.write(new_state.force_encoding(f.external_encoding))
           f.flush
           f.truncate(f.pos)
         end

--- a/spec/unit/synchronized_minter_spec.rb
+++ b/spec/unit/synchronized_minter_spec.rb
@@ -43,6 +43,16 @@ describe ActiveFedora::Noid::SynchronizedMinter do
     it 'is valid' do
       expect(ActiveFedora::Noid::Service.new.valid?(subject)).to be true
     end
+
+    context 'with a non-UTF8 encoding (mimicking the Rails environment)' do
+      subject { ActiveFedora::Noid::SynchronizedMinter.new }
+      before do
+        allow(subject).to receive(:file_opts) { { encoding: Encoding::UTF_8 } }
+      end
+      it 'mints an ID' do
+        expect { subject.mint }.not_to raise_error
+      end
+    end
   end
 
   context "when the pid already exists in Fedora" do


### PR DESCRIPTION
While troubleshooting https://github.com/projecthydra/sufia/pull/1037, I found that the AF::Noid code that writes the output of `Marshal.dump(minter.dump)` to a state file is trying to write an ASCII-8BIT string. This causes Sufia to fail miserably, and here's an example:

```
  1) dashboard/index.html.erb main with transfers renders received and sent transfer requests
     Failure/Error: f.save!
     Encoding::UndefinedConversionError:
       "\xAC" from ASCII-8BIT to UTF-8
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/synchronized_minter.rb:50:in `write'
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/synchronized_minter.rb:50:in `block in next_id'
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/synchronized_minter.rb:43:in `open'
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/synchronized_minter.rb:43:in `next_id'
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/synchronized_minter.rb:15:in `block in mint'
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/synchronized_minter.rb:13:in `synchronize'
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/synchronized_minter.rb:13:in `mint'
     # /home/mjg/workspace/active_fedora-noid/lib/active_fedora/noid/service.rb:17:in `mint'
     # ./sufia-models/app/services/sufia/noid.rb:10:in `assign_id'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/persistence.rb:179:in `assign_rdf_subject'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/persistence.rb:145:in `create_record'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/indexing.rb:45:in `create_record'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/callbacks.rb:237:in `block (2 levels) in create_record'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:115:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:115:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:553:in `block (2 levels) in compile'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:503:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:503:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:88:in `run_callbacks'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/callbacks.rb:237:in `block in create_record'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:115:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:115:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:553:in `block (2 levels) in compile'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:503:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:503:in `call'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:88:in `run_callbacks'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/callbacks.rb:236:in `create_record'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/persistence.rb:139:in `create_or_update'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/persistence.rb:31:in `save!'
     # /home/mjg/.rvm/gems/ruby-2.2.1@sufia/gems/active-fedora-9.3.0/lib/active_fedora/validations.rb:56:in `save!'
     # ./spec/views/dashboard/index_spec.rb:140:in `block (5 levels) in <top (required)>'
     # ./spec/views/dashboard/index_spec.rb:138:in `tap'
     # ./spec/views/dashboard/index_spec.rb:138:in `block (4 levels) in <top (required)>'
```