### PR TITLE
Use the File-backed minter as the default minter.

### DIFF
--- a/lib/active_fedora/noid/config.rb
+++ b/lib/active_fedora/noid/config.rb
@@ -17,7 +17,7 @@ module ActiveFedora
       end
 
       def minter_class
-        @minter_class ||= Minter::Db
+        @minter_class ||= Minter::File
       end
 
       def translate_uri_to_id

--- a/lib/active_fedora/noid/rspec.rb
+++ b/lib/active_fedora/noid/rspec.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveFedora::Noid.configure do |noid_config|
+      noid_config.minter_class = ActiveFedora::Noid::Minter::File
+    end
+  end
+end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -27,7 +27,7 @@ describe ActiveFedora::Noid::Config do
   end
 
   describe '#minter_class' do
-    let(:default) { ActiveFedora::Noid::Minter::Db }
+    let(:default) { ActiveFedora::Noid::Minter::File }
 
     it 'has a default' do
       expect(subject.minter_class).to eq default

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -5,7 +5,7 @@ describe ActiveFedora::Noid::Service do
   end
 
   it 'has a default minter' do
-    expect(subject.minter).to be_instance_of ActiveFedora::Noid::Minter::Db
+    expect(subject.minter).to be_instance_of ActiveFedora::Noid::Minter::File
   end
 
   context 'with a custom minter' do


### PR DESCRIPTION
This continues past behavior from AF::Noid 1.x and helps us get around the viral effect of breaking every downstream gem and app that wipes out DB rows between tests.

Also, provide an rspec module for using a file-backed minter in the test environment.

Once this PR is merged and a new beta release is cut, https://github.com/projecthydra/sufia/pull/2814 can be backed out as it will no longer be needed.